### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that enables AI assistants to interact with WordPress sites through the WordPress REST API. This server provides tools for managing all aspects of WordPress programmatically, including posts, users, comments, categories, tags, and custom endpoints.
 
+<a href="https://glama.ai/mcp/servers/@prathammanocha/wordpress-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@prathammanocha/wordpress-mcp-server/badge" alt="WordPress Server MCP server" />
+</a>
+
 ## Features
 
 ### Post Management


### PR DESCRIPTION
This PR adds a badge for the [WordPress MCP Server](https://glama.ai/mcp/servers/@prathammanocha/wordpress-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@prathammanocha/wordpress-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@prathammanocha/wordpress-mcp-server/badge" alt="WordPress Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.